### PR TITLE
Register navigator to entities instead of views

### DIFF
--- a/airgun/entities/architecture.py
+++ b/airgun/entities/architecture.py
@@ -1,14 +1,40 @@
+from navmazing import NavigateToSibling
+
 from airgun.entities.base import BaseEntity
-from airgun.views.architecture import ArchitectureView
+from airgun.navigation import BaseNavigator, menu_click, navigator
+from airgun.views.architecture import ArchitectureView, ArchitectureDetailsView
 
 
 class ArchitectureEntity(BaseEntity):
 
     def create_architecture(self, values):
-        view = self.navigate_to(ArchitectureView, 'New')
+        view = self.navigate_to(self, 'New')
         view.fill(values)
         view.submit_data()
 
     def search(self, value):
-        view = self.navigate_to(ArchitectureView, 'All')
+        view = self.navigate_to(self, 'All')
         return view.search_element.search(value)
+
+
+@navigator.register(ArchitectureEntity, 'All')
+class ShowAllArchitectures(BaseNavigator):
+    VIEW = ArchitectureView
+
+    def step(self, *args, **kwargs):
+        menu_click(
+            ["//a[@id='hosts_menu']", self.view.navigate_locator],
+            self.view.browser
+        )
+
+
+@navigator.register(ArchitectureEntity, 'New')
+class AddNewArchitecture(BaseNavigator):
+    VIEW = ArchitectureDetailsView
+
+    prerequisite = NavigateToSibling('All')
+
+    def step(self, *args, **kwargs):
+        self.view.browser.wait_for_element(
+            self.parent.new, ensure_page_safe=True)
+        self.parent.browser.click(self.parent.new)

--- a/airgun/entities/login.py
+++ b/airgun/entities/login.py
@@ -1,14 +1,27 @@
 from airgun.entities.base import BaseEntity
+from airgun.navigation import BaseNavigator, navigator
 from airgun.views.login import LoginView
 
 
 class LoginEntity(BaseEntity):
 
     def login(self, values):
-        view = self.navigate_to(LoginView, 'NavigateToLogin')
+        view = self.navigate_to(self, 'NavigateToLogin')
         view.fill(values)
         self.browser.click(view.submit)
 
     def logout(self):
         # fixme: not implemented
         pass
+
+
+@navigator.register(LoginEntity)
+class NavigateToLogin(BaseNavigator):
+    VIEW = LoginView
+
+    def step(self, *args, **kwargs):
+        # fixme: logout() if logged_in
+        pass
+
+    def am_i_here(self, *args, **kwargs):
+        return self.view.is_displayed

--- a/airgun/views/architecture.py
+++ b/airgun/views/architecture.py
@@ -1,7 +1,5 @@
-from navmazing import NavigateToSibling
 from widgetastic.widget import ParametrizedView, View, Text, TextInput
 
-from airgun.navigation import BaseNavigator, menu_click, navigator
 from airgun.widgets import ResourceList, Search
 
 
@@ -37,26 +35,3 @@ class ArchitectureDetailsView(ParametrizedView):
 
     def submit_data(self):
         self.browser.click(self.submit)
-
-
-@navigator.register(ArchitectureView, 'All')
-class ShowAllArchitectures(BaseNavigator):
-    VIEW = ArchitectureView
-
-    def step(self, *args, **kwargs):
-        menu_click(
-            ["//a[@id='hosts_menu']", self.view.navigate_locator],
-            self.view.browser
-        )
-
-
-@navigator.register(ArchitectureView, 'New')
-class AddNewArchitecture(BaseNavigator):
-    VIEW = ArchitectureDetailsView
-
-    prerequisite = NavigateToSibling('All')
-
-    def step(self, *args, **kwargs):
-        self.view.browser.wait_for_element(
-            self.parent.new, ensure_page_safe=True)
-        self.parent.browser.click(self.parent.new)

--- a/airgun/views/login.py
+++ b/airgun/views/login.py
@@ -1,7 +1,5 @@
 from widgetastic.widget import ClickableMixin, Text, TextInput, View
 
-from airgun.navigation import BaseNavigator, navigator
-
 
 class LoginView(View, ClickableMixin):
     username = TextInput(locator='//input[@id="login_login"]')
@@ -12,15 +10,3 @@ class LoginView(View, ClickableMixin):
     def is_displayed(self):
         return self.browser.wait_for_element(
             self.username, exception=False) is not None
-
-
-@navigator.register(LoginView)
-class NavigateToLogin(BaseNavigator):
-    VIEW = LoginView
-
-    def step(self, *args, **kwargs):
-        # fixme: logout() if logged_in
-        pass
-
-    def am_i_here(self, *args, **kwargs):
-        return self.view.is_displayed


### PR DESCRIPTION
After discussion with @mfalesni turns out navigation steps should be registered against entities, not views.
This also allows us to use nice shortcuts like `self.navigate_to(self, 'New')`

<details>
  <summary>Test results</summary>

```python
Testing started at 1:33 PM ...
/Users/andrii/workspace/py3a/bin/python "/Applications/PyCharm CE.app/Contents/helpers/pydev/pydevd.py" --multiproc --qt-support=auto --client 127.0.0.1 --port 61690 --file "/Applications/PyCharm CE.app/Contents/helpers/pycharm/_jb_pytest_runner.py" --path /Users/andrii/workspace/robottelo/tests/foreman/ui_airgun/test_architecture.py -- -v -s
pydev debugger: process 78979 is connecting

Connected to pydev debugger (build 173.4301.16)
Launching py.test with arguments -v -s /Users/andrii/workspace/robottelo/tests/foreman/ui_airgun/test_architecture.py in /Users/andrii/workspace/robottelo/tests/foreman/ui_airgun

2018-02-06 13:33:06 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /Users/andrii/workspace/py3a/bin/python
cachedir: ../../../.cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collecting ... collected 2 items2018-02-06 13:33:06 - conftest - DEBUG - BZ deselect is disabled in settings


test_architecture.py::test_positive_create[UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF] 2018-02-06 13:34:08 - robottelo - DEBUG - Finished Test: tests/foreman/ui_airgun/test_architecture.py/test_positive_create[UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF]

test_architecture.py::test_positive_create_with_os 2018-02-06 13:34:26 - robottelo - DEBUG - Finished Test: tests/foreman/ui_airgun/test_architecture.py/test_positive_create_with_os


========================== 2 passed in 79.35 seconds ===========================2018-02-06 13:33:06 - robottelo - INFO - Entities cleaner disabled
2018-02-06 13:33:06 - robottelo - DEBUG - Started Test: tests/foreman/ui_airgun/test_architecture.py/test_positive_create[UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF]
2018-02-06 13:33:08 - widgetastic_null - INFO - Opening URL: 'https://host-8-241-176.host.centralci.eng.rdu2.redhat.com'
NAVIGATE: Checking if already at NavigateToLogin
NAVIGATE: Already at NavigateToLogin
2018-02-06 13:33:20 - widgetastic_null - INFO - [LoginView/username]: fill('admin') -> True (elapsed 237 ms)
2018-02-06 13:33:20 - widgetastic_null - INFO - [LoginView/password]: fill('changeme') -> True (elapsed 200 ms)
2018-02-06 13:33:20 - widgetastic_null - INFO - [LoginView]: fill({'username': 'admin', 'password': 'changeme'}) -> True (elapsed 439 ms)
NAVIGATE: Checking if already at New
NAVIGATE: I'm not at New
NAVIGATE: Checking if already at All
NAVIGATE: I'm not at All
NAVIGATE: Heading to destination All
NAVIGATE: Heading to destination New
2018-02-06 13:33:43 - widgetastic_null - INFO - [ArchitectureDetailsView/name]: fill('UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF') -> True (elapsed 10518 ms)
2018-02-06 13:33:43 - widgetastic_null - INFO - [ArchitectureDetailsView]: fill({'name': 'UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF'}) -> None (elapsed 10519 ms)
NAVIGATE: Checking if already at All
NAVIGATE: Already at All
2018-02-06 13:34:01 - widgetastic_null - INFO - [ArchitectureView/search_element/search_field]: fill('UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF') -> True (elapsed 11470 ms)
2018-02-06 13:34:01 - widgetastic_null - INFO - [ArchitectureView/search_element]: fill('UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF') -> None (elapsed 11471 ms)
2018-02-06 13:34:07 - widgetastic_null - INFO - [ArchitectureView/search_element/search_button]: click (elapsed 6129 ms)
2018-02-06 13:34:07 - widgetastic_null - INFO - [ArchitectureView/search_element]: read -> 'UunTq9eiEgNNMSeCbn9oGQ8uG4jEJIgNv5y4erDjpDUgorZ3PL4aEUtOrxbKflC4sApwqQiF' (elapsed 32 ms)
PASSED [ 50%]2018-02-06 13:34:08 - robottelo - DEBUG - Started Test: tests/foreman/ui_airgun/test_architecture.py/test_positive_create_with_os
2018-02-06 13:34:08 - nailgun.client - DEBUG - Making HTTP POST request to https://host-8-241-176.host.centralci.eng.rdu2.redhat.com/api/v2/operatingsystems with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"operatingsystem": {"major": "865", "name": "vIVaFzdsypTv"}}.
2018-02-06 13:34:08 - nailgun.client - DEBUG - Received HTTP 201 response: {"description":null,"major":"865","minor":"","family":null,"release_name":null,"password_hash":"SHA256","created_at":"2018-02-06 11:34:06 UTC","updated_at":"2018-02-06 11:34:06 UTC","id":13,"name":"vIVaFzdsypTv","title":"vIVaFzdsypTv 865","media":[],"architectures":[],"ptables":[],"config_templates":[],"provisioning_templates":[],"os_default_templates":[],"images":[],"parameters":[]}
2018-02-06 13:34:10 - widgetastic_null - INFO - Opening URL: 'https://host-8-241-176.host.centralci.eng.rdu2.redhat.com'
NAVIGATE: Checking if already at NavigateToLogin
NAVIGATE: Already at NavigateToLogin
2018-02-06 13:34:17 - widgetastic_null - INFO - [LoginView/username]: fill('admin') -> True (elapsed 228 ms)
2018-02-06 13:34:17 - widgetastic_null - INFO - [LoginView/password]: fill('changeme') -> True (elapsed 227 ms)
2018-02-06 13:34:17 - widgetastic_null - INFO - [LoginView]: fill({'username': 'admin', 'password': 'changeme'}) -> True (elapsed 456 ms)
NAVIGATE: Checking if already at New
NAVIGATE: I'm not at New
NAVIGATE: Checking if already at All
NAVIGATE: I'm not at All
NAVIGATE: Heading to destination All
NAVIGATE: Heading to destination New
2018-02-06 13:34:23 - widgetastic_null - INFO - [ArchitectureDetailsView/name]: fill('grAGznyTbq') -> True (elapsed 264 ms)
2018-02-06 13:34:23 - widgetastic_null - INFO - [ArchitectureDetailsView/os_element/filter]: fill('vIVaFzdsypTv') -> True (elapsed 268 ms)
2018-02-06 13:34:23 - widgetastic_null - INFO - [ArchitectureDetailsView]: fill({'name': 'grAGznyTbq', 'os_names': {'operation': 'Add', 'values': ['vIVaFzdsypTv']}}) -> None (elapsed 597 ms)
NAVIGATE: Checking if already at All
NAVIGATE: Already at All
2018-02-06 13:34:24 - widgetastic_null - INFO - [ArchitectureView/search_element/search_field]: fill('grAGznyTbq') -> True (elapsed 451 ms)
2018-02-06 13:34:24 - widgetastic_null - INFO - [ArchitectureView/search_element]: fill('grAGznyTbq') -> None (elapsed 452 ms)
2018-02-06 13:34:26 - widgetastic_null - INFO - [ArchitectureView/search_element/search_button]: click (elapsed 1192 ms)
2018-02-06 13:34:26 - widgetastic_null - INFO - [ArchitectureView/search_element]: read -> 'grAGznyTbq' (elapsed 34 ms)
PASSED                [100%]
Process finished with exit code 0

```
</details>