### PR TITLE
Use separate navigator instance for each session; fix nested sessions

### DIFF
--- a/airgun/session.py
+++ b/airgun/session.py
@@ -1,4 +1,5 @@
 """Session controller which manages UI session"""
+import copy
 import logging
 import os
 
@@ -124,7 +125,7 @@ class Session(object):
         self._factory.post_init()
 
         # Navigator
-        self.navigator = navigator
+        self.navigator = copy.deepcopy(navigator)
         self.navigator.browser = self.browser
 
         # Entities


### PR DESCRIPTION
Every session was using the same navigator instance, as the only instance (`navigator`) was collecting  destinations tree.
During start of the session, it overrides existing `navigator.browser` attr with session's browser, that's why nested sessions didn't work - after session2 closed, session1 was using navigator which had a link to session2.browser which is closed, causing any navigator call to fail with `[Errno 32] Broken pipe` and `[Errno 111] Connection refused`.
Making a separate copy of navigator for each session to resolve the issue.
Fixes #21 
Test results for sample test with nested session provided in #21:
```python
pytest tests/foreman/ui_airgun/test_os.py::test_unpriviledged_user_delete
============================= test session starts ==============================
platform darwin -- Python 3.6.4, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/andrii/workspace/robottelo, inifile:
plugins: wait-for-1.0.9, xdist-1.22.0, services-1.2.1, mock-1.6.3, forked-0.2
collected 1 item
2018-02-19 16:30:54 - conftest - DEBUG - BZ deselect is disabled in settings


tests/foreman/ui_airgun/test_os.py .                                     [100%]

========================== 1 passed in 66.04 seconds ===========================
```